### PR TITLE
Update django 4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -53,12 +53,16 @@ jobs:
   dependency-check:
     name: Dependency-Check
     runs-on: ubuntu-latest
-    container: autoreduction/base
     strategy:
       fail-fast: false
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,17 +4,17 @@ on: [ push ]
 jobs:
   pytest:
     name: Pytest
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - uses: actions/cache@v2
         with:
@@ -52,7 +52,7 @@ jobs:
 
   dependency-check:
     name: Dependency-Check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container: autoreduction/base
     strategy:
       fail-fast: false
@@ -75,17 +75,17 @@ jobs:
 
   Inspection:
     name: Code Inspection
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - uses: actions/cache@v2
         with:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     description='ISIS Autoreduce',
     author='ISIS Autoreduction Team',
     url='https://github.com/autoreduction/autoreduce-db/',
-    install_requires=['autoreduce-utils==22.0.0.dev7', 'Django==4.0.1'],
+    install_requires=['autoreduce-utils==22.0.0.dev7', 'Django>=3.2.10'],
     packages=find_packages(),
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,11 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='autoreduce_db',
-    version='22.0.0.dev21',
+    version='22.0.0.dev22',
     description='ISIS Autoreduce',
     author='ISIS Autoreduction Team',
     url='https://github.com/autoreduction/autoreduce-db/',
-    install_requires=['autoreduce-utils==22.0.0.dev7', 'Django==3.2.10'],
+    install_requires=['autoreduce-utils==22.0.0.dev7', 'Django==4.0.1'],
     packages=find_packages(),
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Summary of work
Change Django requirement to Django>=3.2.10 to allow Django 4.x when requirements of other dependencies allow.
Update Python version of tests to 3.8 as reduction no longer tied to current environment