### PR TITLE
Remove publishing of PyPi package autoreduce-db

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,16 +43,6 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
-      - name: Build package for publishing
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: python3 -m pip install --upgrade build wheel && python -m build
-
-      - name: Publish distribution 📦 to PyPI
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-
   dependency-check:
     name: Dependency-Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary of work
<!---The changes you have made--->
We no longer need to publish to PyPi, so we will stop.

### How to test your work
<!---This can be a link to the--->
Code review

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?--->

Fixes #105

**Before merging ensure the release notes have been updated**
Release notes updates are not necessary.